### PR TITLE
Add minimal Next.js frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# codex
+# Codex
+
+This repository contains a minimal Next.js frontend for interacting with a multi-agent backend.
+
+## Prerequisites
+
+- Node.js 18+ with npm
+
+## Running the Frontend
+
+1. Install dependencies:
+   ```bash
+   cd frontend
+   npm install
+   ```
+
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+   The app will be available at `http://localhost:3000`.
+
+The frontend expects an agent backend URL specified via `NEXT_PUBLIC_BACKEND_URL`.
+By default it uses `http://localhost:8000`. To change it:
+
+```bash
+NEXT_PUBLIC_BACKEND_URL=http://localhost:5000 npm run dev
+```
+
+The backend should expose a `POST /query` endpoint that returns JSON:
+
+```json
+{
+  "responses": ["agent reply 1", "agent reply 2"]
+}
+```
+
+The web page allows you to send queries and displays the responses.

--- a/frontend/components/Chat.tsx
+++ b/frontend/components/Chat.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+
+interface ResponseMessage {
+  role: string;
+  content: string;
+}
+
+export default function Chat() {
+  const [query, setQuery] = useState('');
+  const [messages, setMessages] = useState<ResponseMessage[]>([]);
+
+  async function sendQuery(e: React.FormEvent) {
+    e.preventDefault();
+    if (!query) return;
+
+    const backend = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000';
+    try {
+      const res = await fetch(`${backend}/query`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      if (Array.isArray(data.responses)) {
+        setMessages(data.responses.map((content: string) => ({ role: 'agent', content })));
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  return (
+    <div className="container">
+      <form onSubmit={sendQuery}>
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Ask something"
+          style={{ width: '80%' }}
+        />
+        <button type="submit">Send</button>
+      </form>
+      <div className="messages">
+        {messages.map((m, idx) => (
+          <div key={idx} className="message">
+            {m.content}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.1.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.4.5"
+  }
+}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,13 @@
+import Head from 'next/head';
+import Chat from '../components/Chat';
+
+export default function Home() {
+  return (
+    <>
+      <Head>
+        <title>Multi-Agent Chat</title>
+      </Head>
+      <Chat />
+    </>
+  );
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,21 @@
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  margin: 0;
+  padding: 1rem;
+}
+
+.container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.messages {
+  margin-top: 1rem;
+}
+
+.message {
+  padding: 0.5rem;
+  border-radius: 4px;
+  background: #f2f2f2;
+  margin-bottom: 0.5rem;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold minimal Next.js app in `frontend`
- implement simple chat component to send queries to backend
- document how to install dependencies and run the frontend

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab26f6ce8832b937893acd191503b